### PR TITLE
Let %autoreload work on modules with frozen dataclasses

### DIFF
--- a/IPython/extensions/autoreload.py
+++ b/IPython/extensions/autoreload.py
@@ -300,7 +300,7 @@ def update_instances(old, new):
 
     for ref in refs:
         if type(ref) is old:
-            ref.__class__ = new
+            object.__setattr__(ref, '__class__', new)
 
 
 def update_class(old, new):


### PR DESCRIPTION
See #12411 and #12185.
The problem is that a frozen `dataclasses.dataclass` overrides the `__setattr__()` method, so updating its `__class__` member requires going through the base `object` class.  This seems to fix the problem.